### PR TITLE
Add iterator to Serie to iterate all point rows with no memory overhead

### DIFF
--- a/src/test/java/org/influxdb/dto/SerieTest.java
+++ b/src/test/java/org/influxdb/dto/SerieTest.java
@@ -1,5 +1,8 @@
 package org.influxdb.dto;
 
+import java.util.Iterator;
+
+import org.influxdb.dto.Serie.Row;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -32,5 +35,21 @@ public class SerieTest {
 		Assert.assertEquals(serie.getRows().size(), 2);
 		Assert.assertEquals(serie.getRows().get(0).size(), 3);
 
+		// test iterator
+		Iterator<Row> iterator = serie.rows();
+
+		Assert.assertTrue(iterator.hasNext());
+		Row first = iterator.next();
+		Assert.assertEquals(first.getColumn(0), 1l);
+		Assert.assertEquals(first.getColumn(1), 96.3f);
+		Assert.assertEquals(first.getColumn(2), "no error");
+
+		Assert.assertTrue(iterator.hasNext());
+		Row second = iterator.next();
+		Assert.assertEquals(second.getColumn("time"), 2l);
+		Assert.assertEquals(second.getColumn("idle"), 69.5f);
+		Assert.assertEquals(second.getColumn("error"), "with error");
+
+		Assert.assertFalse(iterator.hasNext());
 	}
 }


### PR DESCRIPTION
Hi,

I noticed that the getRows() method that returns the list with map for each row is quite non-effective regarding memory footprint.. For each row we would have one map created, which would mean that for a series having 2k rows we would have 2k maps + the list.. That's really a lot of garbage considering that the .newHashMap() method in guava creates an empty hash map with default capacity of 16.. Considering that in most cases serie has only two points (time & value), that's just waist of space.. Especially if we are loading series having more rows (think about 50k).. Also time you need to construct a complete list of rows is quadratic (#numRows * #numColumns), which can be high when having big number of rows and columns..

So I proposed the simple solution of providing the iterator on the Row class.. All operations here are constant, except getPoint(String columnName) which has additional time of C/2 to find corresponding column index.. Regarding memory we are only creating one Row object per row, which has same size as Integer object (16 bytes)..

If you consider series with 2k rows and 2 columns, I am only creating 32k garbage with iterator, while with using getRows it's approximately 352k only for Maps, plus some 8k for list in addition.. 