### PR TITLE
Updated dockerfile. Set influxdb package to v0.8.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu
 MAINTAINER Stefan Majer <stefan.majer [at] gmail.com>
 
-ADD http://s3.amazonaws.com/influxdb/influxdb_latest_amd64.deb /influxdb_latest_amd64.deb
-RUN dpkg -i /influxdb_latest_amd64.deb
+ADD http://s3.amazonaws.com/influxdb/influxdb_0.8.8_amd64.deb /influxdb_0.8.8_amd64.deb
+RUN dpkg -i /influxdb_0.8.8_amd64.deb
 
 EXPOSE 8083 8086
 


### PR DESCRIPTION
It was pulling the latest package, but the driver is not compatible yet with the latest 0.9, it only works up to 0.8.8.