### PR TITLE
Update README.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ BatchPoints batchPoints = BatchPoints
 				.build();
 Point point1 = Point.measurement("cpu")
 					.time(System.currentTimeMillis(), TimeUnit.MILLISECONDS)
-					.field("idle", 90L).field("user", 9L)
+					.field("idle", 90L).field("system", 9L)
 					.field("system", 1L)
 					.build();
 Point point2 = Point.measurement("disk")
@@ -52,7 +52,7 @@ influxDB.enableBatch(2000, 100, TimeUnit.MILLISECONDS);
 
 Point point1 = Point.measurement("cpu")
 					.time(System.currentTimeMillis(), TimeUnit.MILLISECONDS)
-					.field("idle", 90L).field("user", 9L)
+					.field("idle", 90L).field("system", 9L)
 					.field("system", 1L)
 					.build();
 Point point2 = Point.measurement("disk")


### PR DESCRIPTION
Due to issue https://github.com/influxdb/influxdb/issues/3467, the field key named `user` makes InfluxDB return an error. This change prevents users from running into the bug, which will likely be fixed in 0.9.3.