### PR TITLE
Set system time as point's default time.

### DIFF
--- a/src/main/java/org/influxdb/dto/Point.java
+++ b/src/main/java/org/influxdb/dto/Point.java
@@ -143,9 +143,14 @@ public class Point {
 			Point point = new Point();
 			point.setFields(this.fields);
 			point.setMeasurement(this.measurement);
-			point.setPrecision(this.precision);
+			if (this.time != 0) {
+			    point.setTime(this.time);
+			    point.setPrecision(this.precision);
+			} else {
+			    point.setTime(System.currentTimeMillis());
+			    point.setPrecision(TimeUnit.MILLISECONDS);
+			}
 			point.setTags(this.tags);
-			point.setTime(this.time);
 			return point;
 		}
 	}


### PR DESCRIPTION
InfluxDB is what a time series database manually setting time is not necessary.