### PR TITLE
Update InfluxDBTest.java

### DIFF
--- a/src/test/java/org/influxdb/InfluxDBTest.java
+++ b/src/test/java/org/influxdb/InfluxDBTest.java
@@ -166,7 +166,7 @@ public class InfluxDBTest {
 		String dbName = "write_unittest_" + System.currentTimeMillis();
 		this.influxDB.createDatabase(dbName);
 
-		BatchPoints batchPoints = BatchPoints.database(dbName).tag("async", "true").retentionPolicy("default").build();
+		BatchPoints batchPoints = BatchPoints.database(dbName).time(System.currentTimeMillis(), TimeUnit.MILLISECONDS).tag("async", "true").retentionPolicy("default").build();
 		Point point1 = Point
 				.measurement("cpu")
 				.tag("atag", "test")


### PR DESCRIPTION
refer to my last change (I described the change but forgot to add it to the code..)
(in testWrite influxDB.write(batchPoints) has through a null pointer exception because the precision was null)