### PR TITLE
Fixing broken unit test testWrite()

### DIFF
--- a/src/test/java/org/influxdb/InfluxDBTest.java
+++ b/src/test/java/org/influxdb/InfluxDBTest.java
@@ -166,7 +166,7 @@ public class InfluxDBTest {
 		String dbName = "write_unittest_" + System.currentTimeMillis();
 		this.influxDB.createDatabase(dbName);
 
-		BatchPoints batchPoints = BatchPoints.database(dbName).time(System.currentTimeMillis(), TimeUnit.MILLISECONDS).tag("async", "true").retentionPolicy("default").build();
+		BatchPoints batchPoints = BatchPoints.database(dbName).tag("async", "true").retentionPolicy("default").build();
 		Point point1 = Point
 				.measurement("cpu")
 				.tag("atag", "test")
@@ -178,7 +178,7 @@ public class InfluxDBTest {
 		batchPoints.point(point1);
 		batchPoints.point(point2);
 		this.influxDB.write(batchPoints);
-		Query query = new Query("SELECT * FROM cpu", dbName);
+		Query query = new Query("SELECT * FROM cpu GROUP BY *", dbName);
 		QueryResult result = this.influxDB.query(query);
 		Assert.assertFalse(result.getResults().get(0).getSeries().get(0).getTags().isEmpty());
 		this.influxDB.deleteDatabase(dbName);


### PR DESCRIPTION
- This involved:
  - removing the call to .time() on the BatchPoints object which was removed from the BatchPoints api in commit 6006319520166ebf8d3ed907e9f3c8744db773ac
    - adding an explicit GROUP BY * to the query executed as part of the test (Refer to https://github.com/influxdb/influxdb-java/issues/94)