### PR TITLE
Escape equals signs in tag keys/values

### DIFF
--- a/src/main/java/org/influxdb/dto/Point.java
+++ b/src/main/java/org/influxdb/dto/Point.java
@@ -27,7 +27,7 @@ public class Point {
 	private Map<String, Object> fields;
 
 	private static final Escaper FIELD_ESCAPER = Escapers.builder().addEscape('"', "\\\"").build();
-	private static final Escaper KEY_ESCAPER = Escapers.builder().addEscape(' ', "\\ ").addEscape(',', "\\,").build();
+	private static final Escaper KEY_ESCAPER = Escapers.builder().addEscape(' ', "\\ ").addEscape(',', "\\,").addEscape('=', "\\=").build();
 
 	Point() {
 	}

--- a/src/test/java/org/influxdb/dto/PointTest.java
+++ b/src/test/java/org/influxdb/dto/PointTest.java
@@ -128,5 +128,20 @@ public class PointTest {
 		point = Point.measurement("test").time(1, TimeUnit.NANOSECONDS).field("a", bigDecimalNumber).build();
 		assertThat(point.lineProtocol()).asString().isEqualTo("test a=100000000.00000001 1");
 	}
+	
+	@Test
+	public void testEscapingOfKeysAndValues() {
+		// Test escaping of spaces
+		Point point = Point.measurement("test").time(1, TimeUnit.NANOSECONDS).tag("foo", "bar baz").field( "a", 1 ).build();
+		assertThat(point.lineProtocol()).asString().isEqualTo("test,foo=bar\\ baz a=1.0 1");
+ 
+		// Test escaping of commas
+		point = Point.measurement("test").time(1, TimeUnit.NANOSECONDS).tag("foo", "bar,baz").field( "a", 1 ).build();
+		assertThat(point.lineProtocol()).asString().isEqualTo("test,foo=bar\\,baz a=1.0 1");
+
+		// Test escaping of equals sign
+		point = Point.measurement("test").time(1, TimeUnit.NANOSECONDS).tag("foo", "bar=baz").field( "a", 1 ).build();
+		assertThat(point.lineProtocol()).asString().isEqualTo("test,foo=bar\\=baz a=1.0 1");
+	}
 
 }


### PR DESCRIPTION
If you put an equals sign in the Tag key/value, it would throw an 'unable to parse' RuntimeException when trying to write to influx