### PR TITLE
Adding IF NOT EXISTS to the create database statement for influxdb #3892

### DIFF
--- a/src/main/java/org/influxdb/impl/InfluxDBImpl.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBImpl.java
@@ -190,7 +190,7 @@ public class InfluxDBImpl implements InfluxDB {
 	@Override
 	public void createDatabase(final String name) {
 		Preconditions.checkArgument(!name.contains("-"), "Databasename cant contain -");
-		this.influxDBService.query(this.username, this.password, "CREATE DATABASE " + name);
+		this.influxDBService.query(this.username, this.password, "CREATE DATABASE IF NOT EXISTS " + name);
 	}
 
 	/**


### PR DESCRIPTION
Support for CREATE DATABASE [IF NOT EXISTS] was added in https://github.com/influxdb/influxdb/pull/3892. Adding IF NOT EXISTS to the create statement to avoid having to check for the database before creating it.