### PR TITLE
support integer type

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu
 MAINTAINER Stefan Majer <stefan.majer [at] gmail.com>
 
-ADD https://s3.amazonaws.com/influxdb/influxdb_0.9.1_amd64.deb /influxdb_latest_amd64.deb
+ADD https://s3.amazonaws.com/influxdb/influxdb_0.9.4.2_amd64.deb /influxdb_latest_amd64.deb
 RUN dpkg -i /influxdb_latest_amd64.deb
 
 EXPOSE 8083 8086 

--- a/src/test/java/org/influxdb/dto/PointTest.java
+++ b/src/test/java/org/influxdb/dto/PointTest.java
@@ -51,6 +51,18 @@ public class PointTest {
 				.build();
 		assertThat(point.lineProtocol()).asString().isEqualTo("test a=\"A\\\"B\",b=\"D E \\\"F\" 1");
 
+		//Integer type
+		point = Point.measurement("inttest").useInteger(true).time(1, TimeUnit.NANOSECONDS).field("a", (Integer)1).build();
+		assertThat(point.lineProtocol()).asString().isEqualTo("inttest a=1i 1");
+
+		point = Point.measurement("inttest,1").useInteger(true).time(1, TimeUnit.NANOSECONDS).field("a", (Integer)1).build();
+		assertThat(point.lineProtocol()).asString().isEqualTo("inttest\\,1 a=1i 1");
+
+		point = Point.measurement("inttest,1").useInteger(true).time(1, TimeUnit.NANOSECONDS).field("a", 1L).build();
+		assertThat(point.lineProtocol()).asString().isEqualTo("inttest\\,1 a=1i 1");
+
+		point = Point.measurement("inttest,1").useInteger(true).time(1, TimeUnit.NANOSECONDS).field("a", BigInteger.valueOf(100)).build();
+		assertThat(point.lineProtocol()).asString().isEqualTo("inttest\\,1 a=100i 1");
 	}
 
 	/**


### PR DESCRIPTION
I just saw, that the current version of influxdb-java does not support the integer type: https://influxdb.com/docs/v0.9/write_protocols/write_syntax.html

This small change will fix that.