### PR TITLE
Fix for issue #110.

### DIFF
--- a/src/main/java/org/influxdb/InfluxDB.java
+++ b/src/main/java/org/influxdb/InfluxDB.java
@@ -1,6 +1,5 @@
 package org.influxdb;
 
-import java.net.URLConnection;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 

--- a/src/main/java/org/influxdb/dto/Point.java
+++ b/src/main/java/org/influxdb/dto/Point.java
@@ -7,6 +7,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.TimeUnit;
 
+import org.influxdb.exception.NullTagException;
+
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
@@ -268,11 +270,28 @@ public class Point {
 	private StringBuilder concatenatedTags() {
 		final StringBuilder sb = new StringBuilder();
 		for (Entry<String, String> tag : this.tags.entrySet()) {
+			validateTag(tag);
 			sb.append(",");
 			sb.append(KEY_ESCAPER.escape(tag.getKey())).append("=").append(KEY_ESCAPER.escape(tag.getValue()));
 		}
 		sb.append(" ");
 		return sb;
+	}
+
+	/**
+	 * Validates either the entry tag is null or if one of key/value is null.
+	 * 
+	 * @param tag
+	 *            the entry tag to be validated
+	 * @throws NullTagException
+	 *             if either the tag is null or if one of key/value is null
+	 */
+	private void validateTag(final Entry<String, String> tag) throws NullTagException {
+		if (tag == null) {
+			throw new NullTagException("A null tag entry was encountered! Please revew your data.");
+		} else if ((tag.getKey() == null) || (tag.getValue() == null)) {
+			throw new NullTagException("The provided tag has an invalid key/value: " + tag.getKey() + "=" + tag.getValue());
+		}
 	}
 
 	private StringBuilder concatenateFields() {

--- a/src/main/java/org/influxdb/dto/Point.java
+++ b/src/main/java/org/influxdb/dto/Point.java
@@ -290,6 +290,7 @@ public class Point {
 		if (tag == null) {
 			throw new NullTagException("A null tag entry was encountered! Please revew your data.");
 		} else if ((tag.getKey() == null) || (tag.getValue() == null)) {
+			// key is validated for map implementation reasons
 			throw new NullTagException("The provided tag has an invalid key/value: " + tag.getKey() + "=" + tag.getValue());
 		}
 	}

--- a/src/main/java/org/influxdb/exception/InfluxDBException.java
+++ b/src/main/java/org/influxdb/exception/InfluxDBException.java
@@ -1,0 +1,54 @@
+package org.influxdb.exception;
+
+/**
+ * Base class to any InfluxDB exception.
+ */
+public class InfluxDBException extends RuntimeException {
+
+	/**
+	 * The serial version unique identifier.
+	 */
+	private static final long serialVersionUID = -5147473356345660862L;
+
+	/**
+	 * Default constructor for this class.
+	 * 
+	 * Instantiates a new InfluxDB exception.
+	 */
+	public InfluxDBException() {
+		super();
+	}
+
+	/**
+	 * Instantiates a new InfluxDB exception with a customized error message and
+	 * with the cause of the error.
+	 * 
+	 * @param message
+	 *            the customized error message
+	 * @param cause
+	 *            the error cause
+	 */
+	public InfluxDBException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	/**
+	 * Instantiates a new InfluxDB exception with a customized error message.
+	 * 
+	 * @param message
+	 *            the customized error message
+	 */
+	public InfluxDBException(String message) {
+		super(message);
+	}
+
+	/**
+	 * Instantiates a new InfluxDB exception with the cause of the error.
+	 * 
+	 * @param cause
+	 *            the error cause
+	 */
+	public InfluxDBException(Throwable cause) {
+		super(cause);
+	}
+}

--- a/src/main/java/org/influxdb/exception/NullTagException.java
+++ b/src/main/java/org/influxdb/exception/NullTagException.java
@@ -1,0 +1,30 @@
+package org.influxdb.exception;
+
+/**
+ * Class that maps the exception associated to a null InfluxDB tag.
+ */
+public class NullTagException extends InfluxDBException {
+
+	/**
+	 * The serial version unique identifier.
+	 */
+	private static final long serialVersionUID = 5410351166816305312L;
+
+	/**
+	 * Default constructor for this class.
+	 * 
+	 * Instantiates a new NullTag exception.
+	 */
+	public NullTagException() {
+		super();
+	}
+
+	/**
+	 * Instantiates a new NullTag exception with a customized error message.
+	 * 
+	 * @param message the customized error message.
+	 */
+	public NullTagException(String message) {
+		super(message);
+	}
+}

--- a/src/test/java/org/influxdb/dto/PointTest.java
+++ b/src/test/java/org/influxdb/dto/PointTest.java
@@ -156,4 +156,11 @@ public class PointTest {
 		assertThat(point.lineProtocol()).asString().isEqualTo("test,foo=bar\\=baz a=1.0 1");
 	}
 
+	/**
+	 * Test for issue #110.
+	 */
+	@Test
+	public void testNullTag() {
+		
+	}
 }


### PR DESCRIPTION
Fix for issue #110.

Even though the map implementation used to store tags does not allow nullable keys, it is validated this possibility while concatenating tags.

If, in the future, a different map implementation is used, this issue will not reappear.