### PR TITLE
Fix for #110

### DIFF
--- a/src/main/java/org/influxdb/dto/Point.java
+++ b/src/main/java/org/influxdb/dto/Point.java
@@ -89,7 +89,9 @@ public class Point {
 		 * @return the Builder instance.
 		 */
 		public Builder tag(final String tagName, final String value) {
-			this.tags.put(tagName, value);
+			Preconditions.checkArgument(tagName != null);
+			Preconditions.checkArgument(value != null);
+			tags.put(tagName, value);
 			return this;
 		}
 
@@ -101,7 +103,9 @@ public class Point {
 		 * @return the Builder instance.
 		 */
 		public Builder tag(final Map<String, String> tagsToAdd) {
-			this.tags.putAll(tagsToAdd);
+			for (Entry<String, String> tag : tagsToAdd.entrySet()) {
+				tag(tag.getKey(), tag.getValue());
+			}
 			return this;
 		}
 

--- a/src/test/java/org/influxdb/dto/PointTest.java
+++ b/src/test/java/org/influxdb/dto/PointTest.java
@@ -4,11 +4,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.testng.annotations.Test;
+
+import com.google.common.collect.Maps;
 
 /**
  * Test for the Point DTO.
@@ -173,4 +176,33 @@ public class PointTest {
 
 		assertThat(point.lineProtocol()).asString().isEqualTo("nulltest,foo=bar field1=\"value1\",field3=1.0 1");
 	}
+	
+	/**
+	 * Tests for issue #110
+	 */
+	@Test(expectedExceptions = IllegalArgumentException.class)
+	public void testAddingTagsWithNullNameThrowsAnError() {
+		Point.measurement("dontcare").tag(null, "DontCare");
+	}
+	
+	@Test(expectedExceptions = IllegalArgumentException.class)
+	public void testAddingTagsWithNullValueThrowsAnError() {
+		Point.measurement("dontcare").tag("DontCare", null);
+	}
+
+	@Test(expectedExceptions = IllegalArgumentException.class)
+	public void testAddingMapOfTagsWithNullNameThrowsAnError() {
+		Map<String, String> map = Maps.newHashMap();
+		map.put(null, "DontCare");
+		Point.measurement("dontcare").tag(map);
+	}
+
+	@Test(expectedExceptions = IllegalArgumentException.class)
+	public void testAddingMapOfTagsWithNullValueThrowsAnError() {
+		Map<String, String> map = Maps.newHashMap();
+		map.put("DontCare", null);
+		Point.measurement("dontcare").tag(map);
+	}
+	
+	
 }


### PR DESCRIPTION
This is an alternative fix for Issue #110. This set of changes moves the
validation of the input arguments to the point where they are added
(i.e. it moves the locality of failure closer to the point of the
failure). This is offered as an alterntive implementation to the changes
in PR 133.